### PR TITLE
Reuse dot_clk input as externel reset input

### DIFF
--- a/Source/Teensy/MinimalBoot/Min_TeensyROM.h
+++ b/Source/Teensy/MinimalBoot/Min_TeensyROM.h
@@ -32,6 +32,13 @@
   // #define DbgSpecial    //Special case logging to BigBuf
   // #define DbgFab0_3plus     //Only for fab 0.3 or higher PCB! (uses different debug signal)
 
+// Use debug signal line to sense RESET on C64. Use this if you want to trigger
+// an external reset and TeensyROM will boot into the menu again. This requires
+// a hardware modification. On 0.2.x PCBs the trace from dot_clk to U4 needs to
+// be cut and a jumper wire from RESET to the right pin on U4. 0.3.x PCBs require
+// more changes, because this line is configured as output.
+  // #define DbgSignalSenseReset
+
 #define MinimumBuild         //Must be defined for minimal build to identify in common files
 #define Num8kSwapBuffers  16 //space for bank swapping upper blocks of large CRTs
                              //  Must be even number for 16k banks

--- a/Source/Teensy/MinimalBoot/MinimalBoot.ino
+++ b/Source/Teensy/MinimalBoot/MinimalBoot.ino
@@ -60,14 +60,18 @@ void setup()
    SetNMIDeassert;
    SetLEDOn;
    SetResetAssert; //assert reset until main loop()
-  
+
+#ifdef DbgSignalSenseReset
+   pinMode(DotClk_Debug_PIN, INPUT_PULLUP);  //use Dot_Clk input as reset sense input
+#else
 #ifdef DbgFab0_3plus
    pinMode(DotClk_Debug_PIN, OUTPUT);  //p28 is Debug output on fab 0.3+
    SetDebugDeassert;
 #else
    pinMode(DotClk_Debug_PIN, INPUT_PULLUP);  //p28 is Dot_Clk input (unused) on fab 0.2x
 #endif
-
+#endif
+  
    for(uint8_t PinNum=0; PinNum<sizeof(InputPins); PinNum++) pinMode(InputPins[PinNum], INPUT); 
    pinMode(Reset_Btn_In_PIN, INPUT_PULLUP);  //also makes it Schmitt triggered (PAD_HYS)
    pinMode(PHI2_PIN, INPUT_PULLUP);   //also makes it Schmitt triggered (PAD_HYS)
@@ -182,6 +186,9 @@ void loop()
       delay(50); 
       doReset=false;
       SetResetDeassert;
+#ifdef DbgSignalSenseReset
+      attachInterrupt( digitalPinToInterrupt(DotClk_Debug_PIN), isrButton, FALLING );
+#endif
    }
   
    if (Serial.available()) ServiceSerial(&Serial);

--- a/Source/Teensy/Teensy.ino
+++ b/Source/Teensy/Teensy.ino
@@ -69,11 +69,17 @@ void setup()
    SetIRQDeassert;
    SetNMIDeassert;
    SetResetAssert; //assert reset until main loop()
+
+#ifdef DbgSignalSenseReset
+   pinMode(DotClk_Debug_PIN, INPUT_PULLUP);  //use Dot_Clk input as reset sense input
+   attachInterrupt( digitalPinToInterrupt(DotClk_Debug_PIN), isrButton, FALLING );
+#else
 #ifdef DbgFab0_3plus
    pinMode(DotClk_Debug_PIN, OUTPUT);  //p28 is Debug output on fab 0.3+
    SetDebugDeassert;
 #else
    pinMode(DotClk_Debug_PIN, INPUT_PULLUP);  //p28 is Dot_Clk input (unused) on fab 0.2x
+#endif
 #endif
 
    for(uint8_t PinNum=0; PinNum<sizeof(InputPins); PinNum++) pinMode(InputPins[PinNum], INPUT); 
@@ -181,6 +187,9 @@ void loop()
    
    if (doReset)
    {
+#ifdef DbgSignalSenseReset
+      detachInterrupt( digitalPinToInterrupt(DotClk_Debug_PIN) );
+#endif
       SetResetAssert; 
       CmdChannel->println("Resetting C64"); 
       CmdChannel->flush();
@@ -206,6 +215,10 @@ void loop()
       doReset=false;
       BtnPressed = false;
       SetResetDeassert;
+#ifdef DbgSignalSenseReset
+      delay(50); 
+      attachInterrupt( digitalPinToInterrupt(DotClk_Debug_PIN), isrButton, FALLING );
+#endif
    }
   
 #ifdef DbgLEDSignalPolling

--- a/Source/Teensy/TeensyROM.h
+++ b/Source/Teensy/TeensyROM.h
@@ -61,3 +61,10 @@
 // enabling this on a fab 0.2x PBC could cause damage to your C64!
   // #define DbgFab0_3plus     //Only for fab 0.3 or higher PCB! 
 
+// Use debug signal line to sense RESET on C64. Use this if you want to trigger
+// an external reset and TeensyROM will boot into the menu again. This requires
+// a hardware modification. On 0.2.x PCBs the trace from dot_clk to U4 needs to
+// be cut and a jumper wire from RESET to the right pin on U4. 0.3.x PCBs require
+// more changes, because this line is configured as output.
+  // #define DbgSignalSenseReset
+

--- a/Source/Teensy/tools/build-helper.sh
+++ b/Source/Teensy/tools/build-helper.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+COREPATH="$HOME/.arduino15/packages/teensy/hardware/avr/1.59.0/cores/teensy4"
+
+set -e
+
+function upper() {
+  cp ./BootLinkerFiles/bootdata.c.upper $COREPATH/bootdata.c
+  cp ./BootLinkerFiles/imxrt1062_t41.ld.upper $COREPATH/imxrt1062_t41.ld
+  echo "Moved address to upper position. Now please compile Teensy.ino"
+}
+
+function orig() {
+  cp ./BootLinkerFiles/bootdata.c.orig $COREPATH/bootdata.c
+  cp ./BootLinkerFiles/imxrt1062_t41.ld.orig $COREPATH/imxrt1062_t41.ld
+  echo "Moved address to original position. Now please compile MinimalBoot.ino"
+}
+
+function merge() {
+  head -n -2 MinimalBoot.ino.hex > merged.hex
+  head -n -2 Teensy.ino.hex >> merged.hex
+  tail -2 MinimalBoot.ino.hex >> merged.hex
+  echo "Merged upper/lower parts into merged.hex"
+}
+
+case "$1" in
+  upper)
+    upper
+    ;;
+
+  orig)
+    orig
+    ;;
+
+  merge)
+    merge
+    ;;
+
+  ?|help)
+    echo "Usage: $(basename $0) upper|orig|merge"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
This changes reuse the dot_clk input on rev 0.2x PCBs to sense the /RESET line of the C64. With this the TeensyROM gets back into the menu when an internal reset is fired in the C64 (e.g. another reset button or other devices like blue64). The trace from dot_clk to U4 needs to be cut and a jumper wire from RESET to the right pin on U4.

To use this enable `DbgSignalSenseReset` in `TeensyROM.h` and `Min_TeensyROM.h`.