### PR TITLE
Fix: Remote CopyFile() now properly overwrites.

### DIFF
--- a/Source/Teensy/FileTransfer.ino
+++ b/Source/Teensy/FileTransfer.ino
@@ -312,14 +312,16 @@ FLASHMEM void GetDirectoryCommand()
 FLASHMEM bool CopyFile(const char* sourcePath, const char* destinationPath, FS& fs)
 {
     File sourceFile = fs.open(sourcePath, FILE_READ);
+
     if (!sourceFile)
     {
         SendU16(FailToken);
         Serial.printf("Failed to open source file: %s\n", sourcePath);
         return false;
     }
-
+    fs.remove(destinationPath);
     File destinationFile = fs.open(destinationPath, FILE_WRITE);
+
     if (!destinationFile)
     {
         SendU16(FailToken);
@@ -327,14 +329,12 @@ FLASHMEM bool CopyFile(const char* sourcePath, const char* destinationPath, FS& 
         sourceFile.close();
         return false;
     }
-
     while (sourceFile.available())
     {
         uint8_t buf[64];
         size_t len = sourceFile.read(buf, sizeof(buf));
         destinationFile.write(buf, len);
     }
-
     sourceFile.close();
     destinationFile.close();
 
@@ -343,7 +343,9 @@ FLASHMEM bool CopyFile(const char* sourcePath, const char* destinationPath, FS& 
 
 
 // Command: 
-// Copies a command from one folder to the other in the USB/SD storage
+// Copies a command from one folder to the other in the USB/SD storage.
+// If the file with the same name already exists at the destination, 
+// it will be overwritten.
 //
 // Workflow:
 // Receive <-- Post File Token 0x64FF 


### PR DESCRIPTION
### Fix:
Remote CopyFile() routine was appending to the destination file instead of overwriting it when the file already exists.  CopyFile() will now overwrite as originally intended.

### Code Changes:
- the destination file is now deleted before the target is copied over
  - No condition needed to check for pre-existence of dest file as remove() will simply return false if it doesn't.
- Comments also updated to reflect corrected default overwriting behavior