### PR TITLE
Assume Unknown file type is PRG

### DIFF
--- a/Source/Teensy/DriveDirLoad.ino
+++ b/Source/Teensy/DriveDirLoad.ino
@@ -31,7 +31,8 @@ void HandleExecution()
    if (MenuSelCpy.ItemType == rtUnknown)
    {
       SendMsgPrintfln("%s\r\nUnknown File Type", MenuSelCpy.Name);
-      return;
+      MenuSelCpy.ItemType = rtFilePrg; // assume PRG on unknown file type
+      //return;
    }
    
    FS *sourceFS = &firstPartition;

--- a/Source/Teensy/IO_Handlers/IOH_Swiftlink.c
+++ b/Source/Teensy/IO_Handlers/IOH_Swiftlink.c
@@ -465,7 +465,7 @@ void IO1Hndlr_SwiftLink(uint8_t Address, bool R_Wn)
             //combined:
             //  If there's an Rx byte waiting & IRQ(NMI) not currently asserted &
             //     IRQ is enabled & RTS (flow control) is ready
-            if ( (SwiftRegStatus & (SwiftStatusRxFull | SwiftStatusIRQ)) == SwiftStatusRxFull && \  
+            if ( (SwiftRegStatus & (SwiftStatusRxFull | SwiftStatusIRQ)) == SwiftStatusRxFull && \
                 (SwiftRegCommand & (SwiftCmndRxIRQDis | SwiftCmndRTSTxMask)) == SwiftCmndRTSTxRdy ) 
             {  
                CycleCountdown = C64CycBetweenRx;


### PR DESCRIPTION
If the filetype is unknown assume it's a PRG.
Can't hurt to try and load it.  :)

Eliminates the need to identify all possible binary files. (.prg, .bas, .spr, etc.)
Sometimes PRG files don't have an extension.