### PR TITLE
docs: Increase buffer size in CopyFile function for vastly improved f…

### DIFF
--- a/Source/Teensy/FileTransfer.ino
+++ b/Source/Teensy/FileTransfer.ino
@@ -422,9 +422,10 @@ FLASHMEM bool CopyFile(const char* sourcePath, const char* destinationPath, FS& 
         sourceFile.close();
         return false;
     }
+    
+    uint8_t buf[4096];
     while (sourceFile.available())
     {
-        uint8_t buf[4096];
         size_t len = sourceFile.read(buf, sizeof(buf));
         destinationFile.write(buf, len);
     }

--- a/Source/Teensy/FileTransfer.ino
+++ b/Source/Teensy/FileTransfer.ino
@@ -424,7 +424,7 @@ FLASHMEM bool CopyFile(const char* sourcePath, const char* destinationPath, FS& 
     }
     while (sourceFile.available())
     {
-        uint8_t buf[64];
+        uint8_t buf[4096];
         size_t len = sourceFile.read(buf, sizeof(buf));
         destinationFile.write(buf, len);
     }


### PR DESCRIPTION
# Boost File Copy Performance

## Overview
Increases the buffer size in the `CopyFile` function from 64 bytes to 4096 bytes, dramatically improving file copy efficiency in TeensyROM UI applications.  This greatly improves the user experience in the TR UI applications when tagging large favorite files.

## Details:
I discovered this when tagging large favorites files.  The favorite tagging operation was timing out (over 20 seconds) client side waiting for an ACK response.  I increased the timeout to 60s to test, and it worked fine.  I'm not sure how long it actually took, however, 20s is already far too long!  This change is much better and now the operation completes in 600ms.

## Changes
- **File Modified**: `Source/Teensy/FileTransfer.ino`
- **Buffer Size Increased**: 64 → 4096 bytes
- This modification is backward compatible and will **not** introduce a breaking change.